### PR TITLE
Refactored check(Not)Status to checkFeed(Not)Status and checkProcess(Not)Status

### DIFF
--- a/merlin-core/src/main/java/org/apache/falcon/regression/core/util/AssertUtil.java
+++ b/merlin-core/src/main/java/org/apache/falcon/regression/core/util/AssertUtil.java
@@ -18,9 +18,13 @@
 
 package org.apache.falcon.regression.core.util;
 
+import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.response.APIResult;
 import org.apache.falcon.regression.core.response.ServiceResponse;
+import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
 import org.apache.hadoop.fs.Path;
+import org.apache.oozie.client.Job;
+import org.apache.oozie.client.OozieClient;
 import org.testng.Assert;
 
 import javax.xml.bind.JAXBException;
@@ -64,6 +68,47 @@ public class AssertUtil {
         Assert.assertEquals(Util.parseResponse(response).getStatusCode(), 400,
                 message);
         Assert.assertNotNull(Util.parseResponse(response).getRequestId());
+    }
+
+    public static void checkStatus(OozieClient oozieClient, ENTITY_TYPE entityType, String data, Job.Status expectedStatus) throws Exception {
+        String name = null;
+        if(entityType == ENTITY_TYPE.FEED) {
+            name = Util.readDatasetName(data);
+        } else if(entityType == ENTITY_TYPE.PROCESS) {
+            name = Util.readEntityName(data);
+        }
+        Assert.assertEquals(Util.verifyOozieJobStatus(oozieClient, name, entityType, expectedStatus), true);
+    }
+
+    public static void checkStatus(OozieClient oozieClient, ENTITY_TYPE entityType, Bundle bundle, Job.Status expectedStatus) throws Exception {
+        String data = null;
+        if(entityType == ENTITY_TYPE.FEED) {
+            data = bundle.getDataSets().get(0);
+        } else if(entityType == ENTITY_TYPE.PROCESS) {
+            data = bundle.getProcessData();
+        }
+        checkStatus(oozieClient, entityType, data, expectedStatus);
+    }
+
+    public static void checkNotStatus(OozieClient oozieClient, ENTITY_TYPE entityType, String data, Job.Status expectedStatus) throws Exception {
+        String processName = null;
+        if(entityType == ENTITY_TYPE.FEED) {
+            processName = Util.readDatasetName(data);
+        } else if(entityType == ENTITY_TYPE.PROCESS) {
+            processName = Util.readEntityName(data);
+        }
+        Assert.assertNotEquals(Util.getOozieJobStatus(oozieClient, processName,
+                entityType), expectedStatus);
+    }
+
+    public static void checkNotStatus(OozieClient oozieClient, ENTITY_TYPE entityType, Bundle bundle, Job.Status expectedStatus) throws Exception {
+        String data = null;
+        if(entityType == ENTITY_TYPE.FEED) {
+            data = bundle.getDataSets().get(0);
+        } else if(entityType == ENTITY_TYPE.PROCESS) {
+            data = bundle.getProcessData();
+        }
+        checkNotStatus(oozieClient, entityType, data, expectedStatus);
     }
 
 }

--- a/merlin/src/test/java/org/apache/falcon/regression/FeedResumeTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/FeedResumeTest.java
@@ -24,6 +24,7 @@ import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.interfaces.IEntityManagerHelper;
 import org.apache.falcon.regression.core.response.ServiceResponse;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseSingleClusterTests;
@@ -61,16 +62,14 @@ public class FeedResumeTest extends BaseSingleClusterTests {
     public void resumeSuspendedFeed() throws Exception {
         Util.assertSucceeded(feedHelper.submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, feed));
         Util.assertSucceeded(feedHelper.suspend(URLS.SUSPEND_URL, feed));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.SUSPENDED);
         Util.assertSucceeded(feedHelper.resume(URLS.RESUME_URL, feed));
 
         ServiceResponse response = feedHelper.getStatus(URLS.STATUS_URL, feed);
 
         String colo = feedHelper.getColo();
         Assert.assertTrue(response.getMessage().contains(colo + "/RUNNING"));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.RUNNING);
     }
 
 
@@ -94,15 +93,13 @@ public class FeedResumeTest extends BaseSingleClusterTests {
     public void resumeScheduledFeed() throws Exception {
         Util.assertSucceeded(feedHelper.submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, feed));
 
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.RUNNING);
         Util.assertSucceeded(feedHelper.resume(URLS.RESUME_URL, feed));
 
 
         ServiceResponse response = feedHelper.getStatus(URLS.STATUS_URL, feed);
         String colo = feedHelper.getColo();
         Assert.assertTrue(response.getMessage().contains(colo + "/RUNNING"));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.RUNNING);
     }
 }

--- a/merlin/src/test/java/org/apache/falcon/regression/FeedScheduleTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/FeedScheduleTest.java
@@ -26,7 +26,6 @@ import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseSingleClusterTests;
 import org.apache.oozie.client.Job;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -64,8 +63,7 @@ public class FeedScheduleTest extends BaseSingleClusterTests {
 
         response = prism.getFeedHelper().schedule(URLS.SCHEDULE_URL, feed);
         Util.assertSucceeded(response);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.RUNNING);
         //now try re-scheduling again
         response = prism.getFeedHelper().schedule(URLS.SCHEDULE_URL, feed);
         AssertUtil.assertSucceeded(response);
@@ -81,8 +79,7 @@ public class FeedScheduleTest extends BaseSingleClusterTests {
         //now schedule the thing
         response = prism.getFeedHelper().schedule(URLS.SCHEDULE_URL, feed);
         Util.assertSucceeded(response);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.RUNNING);
     }
 
 
@@ -92,12 +89,10 @@ public class FeedScheduleTest extends BaseSingleClusterTests {
 
         //now suspend
         Util.assertSucceeded(prism.getFeedHelper().suspend(URLS.SUSPEND_URL, feed));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.SUSPENDED);
         //now schedule this!
         Util.assertSucceeded(prism.getFeedHelper().schedule(URLS.SCHEDULE_URL, feed));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.SUSPENDED);
     }
 
     @Test(groups = {"singleCluster"})
@@ -106,8 +101,7 @@ public class FeedScheduleTest extends BaseSingleClusterTests {
 
         //now suspend
         Util.assertSucceeded(prism.getFeedHelper().delete(URLS.DELETE_URL, feed));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.KILLED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.KILLED);
         //now schedule this!
         Util.assertFailed(prism.getFeedHelper().schedule(URLS.SCHEDULE_URL, feed));
     }

--- a/merlin/src/test/java/org/apache/falcon/regression/FeedStatusTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/FeedStatusTest.java
@@ -22,6 +22,7 @@ package org.apache.falcon.regression;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.response.ServiceResponse;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseSingleClusterTests;
@@ -77,8 +78,7 @@ public class FeedStatusTest extends BaseSingleClusterTests {
 
         String colo = prism.getFeedHelper().getColo();
         Assert.assertTrue(response.getMessage().contains(colo + "/RUNNING"));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.RUNNING);
     }
 
 
@@ -97,9 +97,7 @@ public class FeedStatusTest extends BaseSingleClusterTests {
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
         String colo = prism.getFeedHelper().getColo();
         Assert.assertTrue(response.getMessage().contains(colo + "/SUSPENDED"));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
-        
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.SUSPENDED);
     }
 
 
@@ -115,8 +113,7 @@ public class FeedStatusTest extends BaseSingleClusterTests {
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
         String colo = prism.getFeedHelper().getColo();
         Assert.assertTrue(response.getMessage().contains(colo + "/SUBMITTED"));
-        Assert.assertTrue(Util.getOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED) != Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.RUNNING);
     }
 
 
@@ -135,8 +132,7 @@ public class FeedStatusTest extends BaseSingleClusterTests {
 
         Assert.assertTrue(
                 response.getMessage().contains(Util.getFeedName(feed) + " (FEED) not found"));
-        Assert.assertTrue(Util.getOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED) != Job.Status.KILLED);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.KILLED);
     }
 
 

--- a/merlin/src/test/java/org/apache/falcon/regression/FeedSubmitAndScheduleTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/FeedSubmitAndScheduleTest.java
@@ -22,6 +22,7 @@ import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.response.APIResult;
 import org.apache.falcon.regression.core.response.ServiceResponse;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseSingleClusterTests;
@@ -79,16 +80,14 @@ public class FeedSubmitAndScheduleTest extends BaseSingleClusterTests {
         Assert.assertEquals(Util.parseResponse(response).getStatus(),
                 APIResult.Status.SUCCEEDED);
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.RUNNING);
         //try to submitand schedule the same process again
         response = prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle.getDataSets().get(0));
 
         Assert.assertEquals(Util.parseResponse(response).getStatusCode(), 200);
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.RUNNING);
     }
 
     @Test(groups = {"singleCluster"})
@@ -114,8 +113,7 @@ public class FeedSubmitAndScheduleTest extends BaseSingleClusterTests {
         Assert.assertEquals(Util.parseResponse(response).getStatus(),
                 APIResult.Status.SUCCEEDED);
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.RUNNING);
         response = prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle.getDataSets().get(0));
 
@@ -139,14 +137,12 @@ public class FeedSubmitAndScheduleTest extends BaseSingleClusterTests {
         Assert.assertEquals(Util.parseResponse(response).getStatus(),
                 APIResult.Status.SUCCEEDED);
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.RUNNING);
         Assert.assertEquals(
                 Util.parseResponse(prism.getFeedHelper()
                         .delete(URLS.DELETE_URL, bundle.getDataSets().get(0)))
                         .getStatusCode(), 200);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.KILLED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.KILLED);
         response = prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle.getDataSets().get(0));
 
@@ -154,8 +150,7 @@ public class FeedSubmitAndScheduleTest extends BaseSingleClusterTests {
         Assert.assertEquals(Util.parseResponse(response).getStatus(),
                 APIResult.Status.SUCCEEDED);
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.RUNNING);
     }
 
 
@@ -173,15 +168,13 @@ public class FeedSubmitAndScheduleTest extends BaseSingleClusterTests {
                 APIResult.Status.SUCCEEDED);
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
         TimeUnit.SECONDS.sleep(20);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.RUNNING);
         Assert.assertEquals(Util.parseResponse(
                 prism.getFeedHelper()
                         .suspend(URLS.SUSPEND_URL, bundle.getDataSets().get(0)))
                 .getStatusCode(),
                 200);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.SUSPENDED);
         response = prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle.getDataSets().get(0));
 
@@ -189,8 +182,7 @@ public class FeedSubmitAndScheduleTest extends BaseSingleClusterTests {
         Assert.assertEquals(Util.parseResponse(response).getStatus(),
                 APIResult.Status.SUCCEEDED);
         Assert.assertNotNull(Util.parseResponse(response).getMessage());
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle, Job.Status.SUSPENDED);
     }
 }
 

--- a/merlin/src/test/java/org/apache/falcon/regression/FeedSuspendTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/FeedSuspendTest.java
@@ -21,6 +21,7 @@ package org.apache.falcon.regression;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.response.ServiceResponse;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseSingleClusterTests;
@@ -67,8 +68,7 @@ public class FeedSuspendTest extends BaseSingleClusterTests {
 
         response = prism.getFeedHelper().suspend(URLS.SUSPEND_URL, feed);
         Util.assertSucceeded(response);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.SUSPENDED);
     }
 
     @Test(groups = {"singleCluster"})
@@ -78,14 +78,11 @@ public class FeedSuspendTest extends BaseSingleClusterTests {
 
         response = prism.getFeedHelper().suspend(URLS.SUSPEND_URL, feed);
         Util.assertSucceeded(response);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.SUSPENDED);
         response = prism.getFeedHelper().suspend(URLS.SUSPEND_URL, feed);
 
         Util.assertSucceeded(response);
-        Assert.assertTrue(Util.verifyOozieJobStatus(server1OC,
-                Util.readDatasetName(feed), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
-
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, feed, Job.Status.SUSPENDED);
     }
 
     @Test(groups = {"singleCluster"})

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/NewPrismProcessUpdateTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/NewPrismProcessUpdateTest.java
@@ -34,6 +34,7 @@ import org.apache.falcon.regression.core.helpers.PrismHelper;
 import org.apache.falcon.regression.core.response.APIResult;
 import org.apache.falcon.regression.core.response.ServiceResponse;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.HadoopUtil;
 import org.apache.falcon.regression.core.util.InstanceUtil;
 import org.apache.falcon.regression.core.util.Util;
@@ -246,7 +247,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
                                         UA2Bundle.getProcessObject().getClusters().getCluster()
                                                 .get(0).getValidity()
                                                 .getEnd())));
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         int expectedNumberOfWorkflows =
                 getExpectedNumberOfWorkflowInstances(newStartTime, InstanceUtil
                         .dateToOozieDate(
@@ -301,7 +302,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
             dualComparisonFailure(UA2Bundle, server3);
             //ensure that the running process has new coordinators created; while the submitted
             // one is updated correctly.
-            checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
             waitForProcessToReachACertainState(server3, UA2Bundle, Job.Status.RUNNING);
             while (Util.parseResponse(
@@ -319,7 +320,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
             Assert.assertEquals(Util.getProcessObject(prismString).getOrder(),
                     UA2Bundle.getProcessObject().getOrder());
             dualComparison(UA2Bundle, server3);
-            checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
             waitingForBundleFinish(server3, oldBundleId);
             int finalNumberOfInstances =
                     InstanceUtil.getProcessInstanceListFromAllBundles(server3,
@@ -384,7 +385,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), true);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
 
@@ -420,7 +421,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), false);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
     @Test(groups = {"multiCluster"}, timeOut = 1200000)
@@ -466,7 +467,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         verifyNewBundleCreation(server3, oldBundleId, 0,
                 Util.readEntityName(UA2Bundle.getProcessData()),
                 false);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         Job.Status status = Util.getOozieJobStatus(server3.getFeedHelper().getOozieClient(),
                 Util.readEntityName(UA2Bundle.getProcessData()), ENTITY_TYPE.PROCESS);
@@ -578,7 +579,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
                                         UA2Bundle.getProcessObject().getClusters().getCluster()
                                                 .get(0).getValidity()
                                                 .getEnd())));
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
     @Test(groups = {"multiCluster"}, timeOut = 1200000)
@@ -625,11 +626,10 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // one is updated correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), false);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         Util.assertSucceeded(server3.getProcessHelper()
                 .resume(URLS.RESUME_URL, UA2Bundle.getProcessData()));
-        Assert.assertTrue(Util.verifyOozieJobStatus(server3.getFeedHelper().getOozieClient(),
-                UA2Bundle.getProcessData(), ENTITY_TYPE.PROCESS, Job.Status.RUNNING));
+        AssertUtil.checkStatus(server3OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         Job.Status status = Util.getOozieJobStatus(server3.getFeedHelper().getOozieClient(),
                 Util.readEntityName(UA2Bundle.getProcessData()), ENTITY_TYPE.PROCESS);
@@ -710,7 +710,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
 
             //ensure that the running process has new coordinators created; while the submitted
             // one is updated correctly.
-            checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
             while (Util
                     .parseResponse(updateProcessConcurrency(UA2Bundle,
@@ -818,7 +818,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // one is updated correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), true);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         waitingForBundleFinish(server3, oldBundleId);
         int finalNumberOfInstances =
                 InstanceUtil.getProcessInstanceListFromAllBundles(server3,
@@ -893,7 +893,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // one is updated correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), true);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         waitingForBundleFinish(server3, oldBundleId);
         int finalNumberOfInstances =
                 InstanceUtil.getProcessInstanceListFromAllBundles(server3,
@@ -959,7 +959,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // one is updated correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), true);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         waitingForBundleFinish(server3, oldBundleId);
 
         int finalNumberOfInstances =
@@ -1031,7 +1031,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // one is updated correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), true);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         waitingForBundleFinish(server3, oldBundleId);
 
         int finalNumberOfInstances =
@@ -1098,7 +1098,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
             // one is updated correctly.
             verifyNewBundleCreation(server3, oldBundleId, coordCount,
                     Util.readEntityName(UA2Bundle.getProcessData()), false);
-            checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
             waitForProcessToReachACertainState(server3, UA2Bundle, Job.Status.RUNNING);
 
             while (Util.parseResponse(
@@ -1113,7 +1113,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
             UA2Bundle.verifyDependencyListing();
             verifyNewBundleCreation(server3, oldBundleId, coordCount,
                     Util.readEntityName(UA2Bundle.getProcessData()), true);
-            checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
             waitingForBundleFinish(server3, oldBundleId);
 
             int finalNumberOfInstances =
@@ -1188,7 +1188,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
                         .getStart(),
                         UA2Bundle.getProcessObject().getClusters().getCluster().get(0)
                                 .getValidity().getEnd()));
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         int expectedNumberOfWorkflows =
                 getExpectedNumberOfWorkflowInstances(InstanceUtil.dateToOozieDate(
                         UA2Bundle.getProcessObject().getClusters().getCluster().get(0)
@@ -1255,7 +1255,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
                         .getStart(),
                         UA2Bundle.getProcessObject().getClusters().getCluster().get(0)
                                 .getValidity().getEnd()));
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
     private void setBundleWFPath(Bundle... bundles) throws Exception {
@@ -1308,7 +1308,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), true);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
 
@@ -1361,7 +1361,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         // one is updated correctly.
         verifyNewBundleCreation(server3, oldBundleId, coordCount,
                 Util.readEntityName(UA2Bundle.getProcessData()), true);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
 
@@ -1414,7 +1414,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
                 getExpectedNumberOfWorkflowInstances(oldStartTime,
                         UA2Bundle.getProcessObject().getClusters().getCluster().get(0)
                                 .getValidity().getEnd()));
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         int expectedNumberOfWorkflows = getExpectedNumberOfWorkflowInstances(newStartTime,
                 UA2Bundle.getProcessObject().getClusters().getCluster().get(0).getValidity()
                         .getEnd());
@@ -1477,7 +1477,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
                 UA2Bundle.getProcessObject().getClusters().getCluster().get(0).getValidity()
                         .getEnd()));
 
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
     @Test(groups = {"multiCluster"}, timeOut = 1200000)
@@ -1531,7 +1531,7 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
                 getExpectedNumberOfWorkflowInstances(oldStartTime,
                         UA2Bundle.getProcessObject().getClusters().getCluster().get(0)
                                 .getValidity().getEnd()));
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
     private String setProcessTimeOut(String process, int mag, TimeUnit unit) throws Exception {
@@ -1756,8 +1756,4 @@ public class NewPrismProcessUpdateTest extends BaseMultiClusterTests {
         return null;
     }
 
-    private void checkNotStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertNotEquals(Util.getOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readEntityName(bundle.getProcessData()), ENTITY_TYPE.PROCESS), expectedStatus);
-    }
 }

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedResumeTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedResumeTest.java
@@ -21,6 +21,7 @@ package org.apache.falcon.regression.prism;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.testHelper.BaseMultiClusterTests;
 import org.apache.oozie.client.Job;
@@ -103,17 +104,17 @@ public class PrismFeedResumeTest extends BaseMultiClusterTests {
         //suspend using prismHelper
         Util.assertFailed(prism.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle1.getDataSets().get(0)));
         //verify
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
         checkAndCompareStatus(server2, bundle2, Job.Status.RUNNING);
         Util.assertSucceeded(prism.getFeedHelper().delete(Util.URLS.DELETE_URL, bundle2.getDataSets().get(0)));
         //suspend on the other one
         Util.assertFailed(prism.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
         Util.assertFailed(server1.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
         Util.assertFailed(server2.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server2, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -146,8 +147,8 @@ public class PrismFeedResumeTest extends BaseMultiClusterTests {
         for (int i = 0; i < 2; i++) {
             //suspend on the other one
             Util.assertSucceeded(prism.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle2.getDataSets().get(0)));
-            checkStatus(server1, bundle1, Job.Status.RUNNING);
-            checkStatus(server2, bundle2, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
         }
 
         for (int i = 0; i < 2; i++) {
@@ -223,24 +224,24 @@ public class PrismFeedResumeTest extends BaseMultiClusterTests {
         //suspend using prismHelper
         Util.assertFailed(prism.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle1.getDataSets().get(0)));
         //verify
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
         checkAndCompareStatus(server2, bundle2, Job.Status.RUNNING);
 
         //suspend using prismHelper
         Util.assertFailed(prism.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle1.getDataSets().get(0)));
         //verify
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
         checkAndCompareStatus(server2, bundle2, Job.Status.RUNNING);
         Util.assertSucceeded(prism.getFeedHelper().delete(Util.URLS.DELETE_URL, bundle2.getDataSets().get(0)));
         //suspend on the other one
         Util.assertFailed(prism.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
 
         Util.assertFailed(server2.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle2.getDataSets().get(0)));
         Util.assertFailed(prism.getFeedHelper().resume(Util.URLS.RESUME_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -285,7 +286,7 @@ public class PrismFeedResumeTest extends BaseMultiClusterTests {
     }
 
     private void checkAndCompareStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        checkStatus(coloHelper, bundle, expectedStatus);
+        AssertUtil.checkStatus(coloHelper.getFeedHelper().getOozieClient(), ENTITY_TYPE.FEED, bundle, expectedStatus);
         String entity = bundle.getDataSets().get(0);
         Assert.assertEquals(Util.parseResponse(prism.getFeedHelper().getStatus(Util.URLS.STATUS_URL, entity)).getMessage(),
                 coloHelper.getFeedHelper().getColo().split("=")[1] + "/" + expectedStatus);
@@ -294,8 +295,4 @@ public class PrismFeedResumeTest extends BaseMultiClusterTests {
                 + Util.parseResponse(coloHelper.getFeedHelper().getStatus(Util.URLS.STATUS_URL, entity)).getMessage());
     }
 
-    private void checkStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertTrue(Util.verifyOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, expectedStatus));
-    }
 }

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedScheduleTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedScheduleTest.java
@@ -20,11 +20,11 @@ package org.apache.falcon.regression.prism;
 
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseMultiClusterTests;
 import org.apache.oozie.client.Job;
-import org.testng.Assert;
 import org.testng.TestNGException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -55,17 +55,12 @@ public class PrismFeedScheduleTest extends BaseMultiClusterTests{
             submitAndScheduleFeed(UA1Bundle);
             Util.assertSucceeded(prism.getFeedHelper()
                     .suspend(URLS.SUSPEND_URL, UA1Bundle.getDataSets().get(0)));
-            Assert.assertTrue(Util.verifyOozieJobStatus(server1.getFeedHelper().getOozieClient(),
-                    Util.readDatasetName(UA1Bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, UA1Bundle, Job.Status.SUSPENDED);
             submitAndScheduleFeed(UA2Bundle);
-            Assert.assertTrue(Util.verifyOozieJobStatus(server2.getFeedHelper().getOozieClient(),
-                    Util.readDatasetName(UA2Bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.RUNNING));
-            Assert.assertTrue(Util.getOozieJobStatus(server2.getFeedHelper().getOozieClient(),
-                    Util.readDatasetName(UA1Bundle.getDataSets().get(0)), ENTITY_TYPE.PROCESS) != Job.Status.RUNNING);
-            Assert.assertTrue(Util.verifyOozieJobStatus(server1.getFeedHelper().getOozieClient(),
-                    Util.readDatasetName(UA1Bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, Job.Status.SUSPENDED));
-            Assert.assertTrue(Util.getOozieJobStatus(server1.getFeedHelper().getOozieClient(),
-                    Util.readDatasetName(UA2Bundle.getDataSets().get(0)), ENTITY_TYPE.PROCESS) != Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, UA1Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getMessage());

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedSnSTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedSnSTest.java
@@ -21,10 +21,10 @@ package org.apache.falcon.regression.prism;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.generated.feed.ActionType;
 import org.apache.falcon.regression.core.generated.feed.ClusterType;
-import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.response.APIResult;
 import org.apache.falcon.regression.core.response.ServiceResponse;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.InstanceUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
@@ -68,17 +68,15 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
     public void testFeedSnSOnBothColos() throws Exception {
         //schedule both bundles
         submitAndScheduleFeed(bundle1);
-        checkStatus(server1, bundle1, Job.Status.RUNNING);
-        Assert.assertNotEquals(Util.getOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle2.getDataSets().get(0)), ENTITY_TYPE.PROCESS), Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
         submitAndScheduleFeed(bundle2);
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
         //check if there is no criss cross
-        Assert.assertNotEquals(Util.getOozieJobStatus(server2OC,
-                Util.readDatasetName(bundle1.getDataSets().get(0)), ENTITY_TYPE.PROCESS), Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -88,12 +86,12 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
         submitAndScheduleFeed(bundle2);
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server1, bundle1, Job.Status.RUNNING);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
         //check if there is no criss cross
-        checkNotStatus(server1, bundle2, Job.Status.RUNNING);
-        checkNotStatus(server2, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
 
 
         Util.assertSucceeded(prism.getFeedHelper()
@@ -106,8 +104,8 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
         Assert.assertEquals(Util.getBundles(server2OC,
                 Util.readDatasetName(bundle2.getDataSets().get(0)), ENTITY_TYPE.FEED).size(), 1);
         //now check if they have been scheduled correctly or not
-        checkStatus(server1, bundle1, Job.Status.RUNNING);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
     }
 
 
@@ -119,32 +117,32 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
 
         Util.assertSucceeded(prism.getFeedHelper()
                 .suspend(URLS.SUSPEND_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
         //now check if they have been scheduled correctly or not
         Util.assertSucceeded(prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
         Assert.assertEquals(Util.getBundles(server1OC,
                 Util.readDatasetName(bundle1.getDataSets().get(0)), ENTITY_TYPE.FEED).size(), 1);
 
         Util.assertSucceeded(server1.getFeedHelper()
                 .resume(URLS.RESUME_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getFeedHelper()
                 .suspend(URLS.SUSPEND_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server2, bundle2, Job.Status.SUSPENDED);
-        checkStatus(server1, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server2, bundle2, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.SUSPENDED);
         Assert.assertEquals(Util.getBundles(server2OC,
                 Util.readDatasetName(bundle2.getDataSets().get(0)), ENTITY_TYPE.FEED).size(), 1);
         Util.assertSucceeded(server2.getFeedHelper()
                 .resume(URLS.RESUME_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
 
     }
@@ -156,12 +154,12 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
         submitAndScheduleFeed(bundle2);
 
         Util.assertSucceeded(prism.getFeedHelper().delete(URLS.DELETE_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getFeedHelper().delete(URLS.DELETE_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server2, bundle2, Job.Status.KILLED);
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
 
         Util.assertSucceeded(prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle1.getDataSets().get(0)));
@@ -190,10 +188,9 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle2.getDataSets().get(0)));
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
         //check if there is no criss cross
-        Assert.assertNotEquals(Util.getOozieJobStatus(server2OC,
-                Util.readDatasetName(bundle1.getDataSets().get(0)), ENTITY_TYPE.PROCESS), Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.RUNNING);
     }
 
 
@@ -206,8 +203,7 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
 
         Util.assertFailed(prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle1.getDataSets().get(0)));
-        Assert.assertNotEquals(Util.getOozieJobStatus(server2OC,
-                Util.readDatasetName(bundle1.getDataSets().get(0)), ENTITY_TYPE.PROCESS), Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -215,24 +211,24 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
         submitAndScheduleFeed(bundle1);
         Util.assertSucceeded(prism.getFeedHelper()
                 .suspend(URLS.SUSPEND_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
         submitAndScheduleFeed(bundle2);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
-        checkNotStatus(server2, bundle1, Job.Status.RUNNING);
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-        checkNotStatus(server1, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
     public void testFeedSnSOn1ColoWhileAnotherColoHasKilledFeed() throws Exception {
         submitAndScheduleFeed(bundle1);
         Util.assertSucceeded(prism.getFeedHelper().delete(URLS.DELETE_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
         submitAndScheduleFeed(bundle2);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
-        checkNotStatus(server2, bundle1, Job.Status.RUNNING);
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkNotStatus(server1, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -242,13 +238,13 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
         APIResult result = Util.parseResponse((server1.getFeedHelper()
                 .submitEntity(URLS.SUBMIT_AND_SCHEDULE_URL, bundle1.getDataSets().get(0))));
         Assert.assertEquals(result.getStatusCode(), 404);
-        checkNotStatus(server1, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
         submitFeed(bundle2);
         result = Util.parseResponse(server2.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle2.getDataSets().get(0)));
         Assert.assertEquals(result.getStatusCode(), 404);
 
-        checkNotStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
     }
 
 
@@ -265,19 +261,19 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
 
         Util.assertSucceeded(server1.getFeedHelper()
                 .suspend(URLS.SUSPEND_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
         //now check if they have been scheduled correctly or not
         Util.assertSucceeded(prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
         Util.assertSucceeded(server1.getFeedHelper().resume(URLS.RESUME_URL, bundle1.getDataSets().get(0)));
 
         Util.assertSucceeded(server2.getFeedHelper().suspend(URLS.SUSPEND_URL, bundle2.getDataSets().get(0)));
         Util.assertSucceeded(prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server2, bundle2, Job.Status.SUSPENDED);
-        checkStatus(server1, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
     }
 
 
@@ -289,12 +285,12 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
         submitAndScheduleFeed(bundle2);
 
         Util.assertSucceeded(prism.getFeedHelper().delete(URLS.DELETE_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getFeedHelper().delete(URLS.DELETE_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server2, bundle2, Job.Status.KILLED);
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
         Util.assertSucceeded(prism.getFeedHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle1.getDataSets().get(0)));
         Util.assertSucceeded(prism.getFeedHelper()
@@ -334,10 +330,9 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, bundle2.getDataSets().get(0)));
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
         //check if there is no criss cross
-        Assert.assertNotEquals(Util.getOozieJobStatus(server2OC,
-                Util.readDatasetName(bundle1.getDataSets().get(0)), ENTITY_TYPE.PROCESS), Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.RUNNING);
     }
 
 
@@ -395,15 +390,13 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
     public void testFeedSnSOn1ColoWhileAnotherColoHasSuspendedFeedUsingColoHelper() throws Exception {
         submitAndScheduleFeed(bundle1);
         Util.assertSucceeded(bundle1.getFeedHelper().suspend(URLS.SUSPEND_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
 
         submitAndScheduleFeed(bundle2);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
-        Assert.assertNotEquals(Util.getOozieJobStatus(server2OC,
-                Util.readDatasetName(bundle1.getDataSets().get(0)), ENTITY_TYPE.PROCESS), Job.Status.RUNNING);
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-        Assert.assertNotEquals(Util.getOozieJobStatus(server1OC,
-                Util.readDatasetName(bundle2.getDataSets().get(0)), ENTITY_TYPE.PROCESS), Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
     }
 
 
@@ -411,22 +404,12 @@ public class PrismFeedSnSTest extends BaseMultiClusterTests{
     public void testFeedSnSOn1ColoWhileAnotherColoHasKilledFeedUsingColoHelper() throws Exception {
         submitAndScheduleFeed(bundle1);
         Util.assertSucceeded(prism.getFeedHelper().delete(URLS.DELETE_URL, bundle1.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
         submitAndScheduleFeed(bundle2);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
-        checkNotStatus(server2, bundle1, Job.Status.RUNNING);
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkNotStatus(server1, bundle2, Job.Status.RUNNING);
-    }
-
-    private void checkStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertTrue(Util.verifyOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, expectedStatus));
-    }
-
-    private void checkNotStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertNotEquals(Util.getOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED), expectedStatus);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.FEED, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
     }
 
     private void submitFeed(Bundle bundle) throws Exception {

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedSuspendTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedSuspendTest.java
@@ -21,12 +21,11 @@ package org.apache.falcon.regression.prism;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.testHelper.BaseMultiClusterTests;
 import org.apache.oozie.client.Job;
-import org.testng.Assert;
 import org.testng.TestNGException;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -60,16 +59,16 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
         Util.assertFailed(prism.getFeedHelper()
                 .suspend(Util.URLS.SUSPEND_URL, bundle1.getDataSets().get(0)));
         //verify
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getFeedHelper()
                 .delete(Util.URLS.DELETE_URL, bundle2.getDataSets().get(0)));
         //suspend on the other one
         Util.assertFailed(prism.getFeedHelper()
                 .suspend(Util.URLS.SUSPEND_URL, bundle2.getDataSets().get(0)));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -85,8 +84,8 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
                             .suspend(Util.URLS.SUSPEND_URL, bundle1.getDataSets().get(0))
             );
             //verify
-            checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-            checkStatus(server2, bundle2, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
         }
 
         for (int i = 0; i < 2; i++) {
@@ -95,8 +94,8 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
                     prism.getFeedHelper()
                             .suspend(Util.URLS.SUSPEND_URL, bundle2.getDataSets().get(0))
             );
-            checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-            checkStatus(server2, bundle2, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.SUSPENDED);
         }
     }
 
@@ -147,13 +146,13 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
                             .suspend(Util.URLS.SUSPEND_URL, bundle1.getDataSets().get(0))
             );
             //verify
-            checkStatus(server2, bundle2, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
             //suspend on the other one
             Util.assertSucceeded(
                     prism.getFeedHelper()
                             .suspend(Util.URLS.SUSPEND_URL, bundle2.getDataSets().get(0)));
-            checkStatus(server2, bundle2, Job.Status.SUSPENDED);;
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.SUSPENDED);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getCause());
@@ -182,8 +181,8 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
                     prism.getFeedHelper()
                             .suspend(Util.URLS.SUSPEND_URL, bundle1.getDataSets().get(0)));
             //verify
-            checkStatus(server1, bundle1, Job.Status.KILLED);
-            checkStatus(server2, bundle2, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
             Util.assertSucceeded(
                     prism.getFeedHelper()
@@ -194,8 +193,8 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
                     prism.getFeedHelper()
                             .suspend(Util.URLS.SUSPEND_URL, bundle2.getDataSets().get(0))
             );
-            checkStatus(server1, bundle1, Job.Status.KILLED);
-            checkStatus(server2, bundle2, Job.Status.KILLED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.KILLED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.KILLED);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getCause());
@@ -218,8 +217,8 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
                             .suspend(Util.URLS.SUSPEND_URL, bundle1.getDataSets().get(0))
             );
             //verify
-            checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-            checkStatus(server2, bundle2, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.RUNNING);
 
             Util.shutDownService(server1.getFeedHelper());
 
@@ -232,8 +231,8 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
             Util.assertSucceeded(
                     prism.getFeedHelper()
                             .suspend(Util.URLS.SUSPEND_URL, bundle2.getDataSets().get(0)));
-            checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-            checkStatus(server2, bundle2, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.FEED, bundle1, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.FEED, bundle2, Job.Status.SUSPENDED);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -295,12 +294,6 @@ public class PrismFeedSuspendTest extends BaseMultiClusterTests {
             Util.restartService(server1.getProcessHelper());
         }
     }
-
-    private void checkStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertTrue(Util.verifyOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readDatasetName(bundle.getDataSets().get(0)), ENTITY_TYPE.FEED, expectedStatus));
-    }
-
 
     private void submitFeed(Bundle bundle) throws Exception {
 

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessResumeTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessResumeTest.java
@@ -21,11 +21,11 @@ package org.apache.falcon.regression.prism;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseMultiClusterTests;
 import org.apache.oozie.client.Job;
-import org.testng.Assert;
 import org.testng.TestNGException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -59,15 +59,15 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
         Util.assertSucceeded(prism.getProcessHelper()
                 .suspend(Util.URLS.SUSPEND_URL, UA1Bundle.getProcessData()));
         //verify
-        checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         //suspend using prism
         Util.assertSucceeded(prism.getProcessHelper()
                 .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
         //verify
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         //try using the colohelper                
         Util.assertSucceeded(
@@ -75,28 +75,28 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                         .suspend(Util.URLS.SUSPEND_URL, UA1Bundle.getProcessData())
         );
         //verify
-        checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         //suspend using prism
         Util.assertSucceeded(server2.getProcessHelper()
                 .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
         //verify
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         //suspend on the other one
         Util.assertSucceeded(
                 server1.getProcessHelper()
                         .suspend(Util.URLS.SUSPEND_URL, UA2Bundle.getProcessData())
         );
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-        checkStatus(server1, UA2Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.SUSPENDED);
 
         Util.assertSucceeded(server1.getProcessHelper()
                 .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -114,23 +114,23 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
         Util.assertFailed(prism.getProcessHelper()
                 .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
         //verify
-        checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getProcessHelper()
                 .delete(Util.URLS.DELETE_URL, UA2Bundle.getProcessData()));
         //suspend on the other one
         Util.assertFailed(prism.getProcessHelper()
                 .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-        checkStatus(server1, UA2Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.KILLED);
 
         Util.assertFailed(server2.getProcessHelper()
                 .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
         Util.assertFailed(server1.getProcessHelper()
                 .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData()));
-        checkStatus(server1, UA2Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.KILLED);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -141,7 +141,7 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
 
         Util.assertSucceeded(prism.getProcessHelper()
                 .suspend(Util.URLS.SUSPEND_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
 
         for (int i = 0; i < 2; i++) {
             //suspend using prism
@@ -149,14 +149,14 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                     prism.getProcessHelper()
                             .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
             //verify
-            checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         }
 
 
         Util.assertSucceeded(prism.getProcessHelper()
                 .suspend(Util.URLS.SUSPEND_URL, UA2Bundle.getProcessData()));
-        checkStatus(server1, UA2Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.SUSPENDED);
 
         for (int i = 0; i < 2; i++) {
             Util.assertSucceeded(
@@ -164,8 +164,8 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                             .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData())
             );
             //verify
-            checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-            checkStatus(server1, UA2Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.SUSPENDED);
         }
 
 
@@ -175,8 +175,8 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                     prism.getProcessHelper()
                             .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData())
             );
-            checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         }
 
         for (int i = 0; i < 2; i++) {
@@ -185,8 +185,8 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                     server1.getProcessHelper()
                             .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData())
             );
-            checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         }
     }
 
@@ -243,14 +243,14 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
             Util.assertFailed(prism.getProcessHelper()
                     .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
             //verify
-            checkStatus(server1, UA2Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.SUSPENDED);
 
             //resume on the other one
             Util.assertSucceeded(
                     prism.getProcessHelper()
                             .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData()));
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
-            checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getCause());
@@ -280,15 +280,15 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
             Util.assertFailed(prism.getProcessHelper()
                     .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
             //verify
-            checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
             //suspend using prism
             Util.assertFailed(prism.getProcessHelper()
                     .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
             //verify
-            checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
             Util.assertSucceeded(
                     prism.getProcessHelper()
@@ -297,15 +297,15 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
             //suspend on the other one
             Util.assertFailed(prism.getProcessHelper()
                     .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData()));
-            checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-            checkStatus(server1, UA2Bundle, Job.Status.KILLED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.KILLED);
 
             Util.assertFailed(
                     server1.getProcessHelper()
                             .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData())
             );
-            checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-            checkStatus(server1, UA2Bundle, Job.Status.KILLED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.KILLED);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getCause());
@@ -327,12 +327,12 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                             .suspend(Util.URLS.SUSPEND_URL, UA1Bundle.getProcessData())
             );
             //verify
-            checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
             Util.assertSucceeded(
                     server2.getProcessHelper()
                             .resume(Util.URLS.RESUME_URL, UA1Bundle.getProcessData()));
-            checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
             Util.shutDownService(server2.getProcessHelper());
 
             Util.assertFailed(prism.getProcessHelper()
@@ -342,15 +342,15 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
             Util.assertSucceeded(
                     prism.getProcessHelper()
                             .suspend(Util.URLS.SUSPEND_URL, UA2Bundle.getProcessData()));
-            checkStatus(server1, UA2Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.SUSPENDED);
 
             for (int i = 0; i < 2; i++) {
                 //suspend on the other one
                 Util.assertSucceeded(
                         prism.getProcessHelper()
                                 .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData()));
-                checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-                checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+                AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+                AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
             }
 
             for (int i = 0; i < 2; i++) {
@@ -358,8 +358,8 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                 Util.assertSucceeded(
                         server1.getProcessHelper()
                                 .resume(Util.URLS.RESUME_URL, UA2Bundle.getProcessData()));
-                checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-                checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+                AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+                AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
             }
 
         } catch (Exception e) {
@@ -443,8 +443,4 @@ public class PrismProcessResumeTest extends BaseMultiClusterTests {
                 .schedule(Util.URLS.SCHEDULE_URL, bundle.getProcessData()));
     }
 
-    private void checkStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertTrue(Util.verifyOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readEntityName(bundle.getProcessData()), ENTITY_TYPE.PROCESS, expectedStatus));
-    }
 }

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessScheduleTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessScheduleTest.java
@@ -19,13 +19,12 @@
 package org.apache.falcon.regression.prism;
 
 import org.apache.falcon.regression.core.bundle.Bundle;
-import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseMultiClusterTests;
 import org.apache.oozie.client.Job;
-import org.testng.Assert;
 import org.testng.TestNGException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -51,16 +50,16 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
     public void testProcessScheduleOnBothColos() throws Exception {
         //schedule both bundles
         submitAndScheduleProcess(UA1Bundle);
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         submitAndScheduleProcess(UA2Bundle);
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         //check if there is no criss cross
-        checkNotStatus(server1, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
 
     }
 
@@ -71,20 +70,20 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
         submitAndScheduleProcess(UA2Bundle);
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         //check if there is no criss cross
-        checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
-        checkNotStatus(server1, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
 
         Util.assertSucceeded(server2.getProcessHelper()
                 .schedule(URLS.SCHEDULE_URL, UA1Bundle.getProcessData()));
         Util.assertSucceeded(server1.getProcessHelper()
                 .schedule(URLS.SCHEDULE_URL, UA2Bundle.getProcessData()));
         //now check if they have been scheduled correctly or not
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
     }
 
@@ -96,21 +95,21 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
 
         Util.assertSucceeded(server2.getProcessHelper()
                 .suspend(URLS.SUSPEND_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         //now check if they have been scheduled correctly or not
 
         Util.assertSucceeded(server2.getProcessHelper()
                 .schedule(URLS.SCHEDULE_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
         Util.assertSucceeded(server2.getProcessHelper()
                 .resume(URLS.RESUME_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
 
         Util.assertSucceeded(server1.getProcessHelper()
                 .suspend(URLS.SUSPEND_URL, UA2Bundle.getProcessData()));
-        checkStatus(server1, UA2Bundle, Job.Status.SUSPENDED);
-        checkStatus(server2, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -121,13 +120,13 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
 
         Util.assertSucceeded(
                 prism.getProcessHelper().delete(URLS.DELETE_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-        checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         Util.assertSucceeded(
                 prism.getProcessHelper().delete(URLS.DELETE_URL, UA2Bundle.getProcessData()));
-        checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-        checkStatus(server1, UA2Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.KILLED);
 
         Util.assertFailed(server2.getProcessHelper()
                 .schedule(URLS.SCHEDULE_URL, UA1Bundle.getProcessData()));
@@ -158,10 +157,10 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
                     .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA2Bundle.getProcessData()));
 
             //now check if they have been scheduled correctly or not
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
             //check if there is no criss cross
-            checkNotStatus(server1, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getMessage());
@@ -180,7 +179,7 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
 
             Util.assertFailed(prism.getProcessHelper()
                     .schedule(URLS.SCHEDULE_URL, UA1Bundle.getProcessData()));
-            checkNotStatus(server1, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getMessage());
@@ -197,13 +196,13 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
             submitAndScheduleProcess(UA1Bundle);
             Util.assertSucceeded(UA1Bundle.getProcessHelper()
                     .suspend(URLS.SUSPEND_URL, UA1Bundle.getProcessData()));
-            checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
 
             submitAndScheduleProcess(UA2Bundle);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
-            checkNotStatus(server1, UA1Bundle, Job.Status.RUNNING);
-            checkStatus(server2, UA1Bundle, Job.Status.SUSPENDED);
-            checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -219,13 +218,13 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
             submitAndScheduleProcess(UA1Bundle);
             Util.assertSucceeded(prism.getProcessHelper()
                     .delete(URLS.DELETE_URL, UA1Bundle.getProcessData()));
-            checkStatus(server2, UA1Bundle, Job.Status.KILLED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
 
             submitAndScheduleProcess(UA2Bundle);
-            checkStatus(server1, UA2Bundle, Job.Status.RUNNING);
-            checkNotStatus(server1, UA1Bundle, Job.Status.RUNNING);
-            checkStatus(server2, UA1Bundle, Job.Status.KILLED);
-            checkNotStatus(server2, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
+            AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+            AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         } catch (Exception e) {
             e.printStackTrace();
             throw new TestNGException(e.getMessage());
@@ -261,13 +260,4 @@ public class PrismProcessScheduleTest extends BaseMultiClusterTests {
                 .schedule(Util.URLS.SCHEDULE_URL, bundle.getProcessData()));
     }
 
-    private void checkStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertTrue(Util.verifyOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readEntityName(bundle.getProcessData()), ENTITY_TYPE.PROCESS, expectedStatus));
-    }
-
-    private void checkNotStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertNotEquals(Util.getOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readEntityName(bundle.getProcessData()), ENTITY_TYPE.PROCESS), expectedStatus);
-    }
 }

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessSnSTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessSnSTest.java
@@ -25,11 +25,11 @@ package org.apache.falcon.regression.prism;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.response.ServiceResponse;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseMultiClusterTests;
 import org.apache.oozie.client.Job;
-import org.apache.oozie.client.OozieClient;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -57,18 +57,18 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
     public void testProcessSnSOnBothColos() throws Exception {
         //schedule both bundles
         submitAndScheduleProcess(UA1Bundle);
-        checkStatus(server2OC, UA1Bundle, Job.Status.RUNNING);
-        checkNotStatus(server2OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         submitAndScheduleProcess(UA2Bundle);
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server1OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         //check if there is no criss cross
         ServiceResponse response =
                 prism.getProcessHelper()
                         .getStatus(URLS.STATUS_URL, UA2Bundle.getProcessData());
         System.out.println(response.getMessage());
-        checkNotStatus(server1OC, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
 
     }
 
@@ -78,16 +78,16 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
         submitProcess(UA1Bundle);
         Util.assertSucceeded(prism.getProcessHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2OC, UA1Bundle, Job.Status.RUNNING);
-        checkNotStatus(server2OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
 
         submitProcess(UA2Bundle);
         Util.assertSucceeded(prism.getProcessHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA1Bundle.getProcessData()));
         //now check if they have been scheduled correctly or not
-        checkStatus(server2OC, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
         //check if there is no criss cross
-        checkNotStatus(server1OC, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
 
     }
 
@@ -98,15 +98,15 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
         submitProcess(UA1Bundle);
         Util.assertSucceeded(prism.getProcessHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2OC, UA1Bundle, Job.Status.RUNNING);
-        checkNotStatus(server2OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         submitProcess(UA2Bundle);
         Util.assertSucceeded(prism.getProcessHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA1Bundle.getProcessData()));
         //now check if they have been scheduled correctly or not
-        checkStatus(server2OC, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
         //check if there is no criss cross
-        checkNotStatus(server1OC, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
 
     }
 
@@ -114,14 +114,14 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
     public void testProcessSnSAlreadyScheduledOnBothColos() throws Exception {
         //schedule both bundles
         submitAndScheduleProcess(UA1Bundle);
-        checkStatus(server2OC, UA1Bundle, Job.Status.RUNNING);
-        checkNotStatus(server2OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         submitAndScheduleProcess(UA2Bundle);
 
         //now check if they have been scheduled correctly or not
-        checkStatus(server1OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         //check if there is no criss cross
-        checkNotStatus(server1OC, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server1OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
 
         //reschedule trial
 
@@ -129,8 +129,8 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
                 .schedule(URLS.SCHEDULE_URL, UA1Bundle.getProcessData()));
         Assert.assertEquals(Util.getBundles(server2.getFeedHelper().getOozieClient(),
                 Util.readEntityName(UA1Bundle.getProcessData()), ENTITY_TYPE.PROCESS).size(), 1);
-        checkStatus(server2OC, UA1Bundle, Job.Status.RUNNING);
-        checkNotStatus(server2OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.RUNNING);
+        AssertUtil.checkNotStatus(server2OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -141,8 +141,8 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
 
         Util.assertSucceeded(server2.getProcessHelper()
                 .suspend(URLS.SUSPEND_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2OC, UA1Bundle, Job.Status.SUSPENDED);
-        checkStatus(server1OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         //now check if they have been scheduled correctly or not
         Util.assertSucceeded(prism.getProcessHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA1Bundle.getProcessData()));
@@ -158,8 +158,8 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
 
         Assert.assertEquals(Util.getBundles(server1.getFeedHelper().getOozieClient(),
                 Util.readEntityName(UA2Bundle.getProcessData()), ENTITY_TYPE.PROCESS).size(), 1);
-        checkStatus(server1OC, UA2Bundle, Job.Status.SUSPENDED);
-        checkStatus(server2OC, UA1Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.SUSPENDED);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -181,12 +181,12 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
 
         Util.assertSucceeded(
                 prism.getProcessHelper().delete(URLS.DELETE_URL, UA1Bundle.getProcessData()));
-        checkStatus(server2OC, UA1Bundle, Job.Status.KILLED);
-        checkStatus(server1OC, UA2Bundle, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.RUNNING);
         Util.assertSucceeded(
                 prism.getProcessHelper().delete(URLS.DELETE_URL, UA2Bundle.getProcessData()));
-        checkStatus(server1OC, UA2Bundle, Job.Status.KILLED);
-        checkStatus(server2OC, UA1Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, UA2Bundle, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, UA1Bundle, Job.Status.KILLED);
         Util.assertSucceeded(prism.getProcessHelper()
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA1Bundle.getProcessData()));
         Util.assertSucceeded(prism.getProcessHelper()
@@ -216,16 +216,6 @@ public class PrismProcessSnSTest extends BaseMultiClusterTests {
                 .submitAndSchedule(URLS.SUBMIT_AND_SCHEDULE_URL, UA2Bundle.getProcessData()))
                 .getStatusCode(), 404);
 
-    }
-
-    private void checkStatus(OozieClient client, Bundle bundle, Job.Status status) throws Exception {
-        Assert.assertTrue(Util.verifyOozieJobStatus(client, Util.readEntityName(bundle.getProcessData()),
-                ENTITY_TYPE.PROCESS, status));
-    }
-
-    private void checkNotStatus(OozieClient client, Bundle bundle, Job.Status status) throws Exception {
-        Assert.assertTrue(Util.getOozieJobStatus(client, Util.readEntityName(bundle.getProcessData()),
-                ENTITY_TYPE.PROCESS) != status);
     }
 
     private void submitProcess(Bundle bundle) throws Exception {

--- a/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessSuspendTest.java
+++ b/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessSuspendTest.java
@@ -21,6 +21,7 @@ package org.apache.falcon.regression.prism;
 import org.apache.falcon.regression.core.bundle.Bundle;
 import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.supportClasses.ENTITY_TYPE;
+import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.Util;
 import org.apache.falcon.regression.core.util.Util.URLS;
 import org.apache.falcon.regression.testHelper.BaseMultiClusterTests;
@@ -73,8 +74,8 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
         //suspend using prismHelper
         Util.assertSucceeded(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle1.getProcessData()));
         //verify
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
 
         Util.shutDownService(server1.getProcessHelper());
 
@@ -83,8 +84,8 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
         for (int i = 0; i < 2; i++) {
             //suspend on the other one
             Util.assertSucceeded(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle2.getProcessData()));
-            checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-            checkStatus(server2, bundle2, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.SUSPENDED);
         }
     }
 
@@ -98,13 +99,13 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
         //suspend using prismHelper
         Util.assertSucceeded(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle1.getProcessData()));
         //verify
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
 
         //suspend on the other one
         Util.assertSucceeded(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle1.getProcessData()));
-        checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
 
         Assert.assertTrue(Util.parseResponse(prism.getProcessHelper()
                 .getStatus(URLS.STATUS_URL, bundle1.getProcessData())).getMessage().contains("SUSPENDED"));
@@ -125,14 +126,14 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
         //suspend using prismHelper
         Util.assertFailed(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle1.getProcessData()));
         //verify
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getProcessHelper().delete(Util.URLS.DELETE_URL, bundle2.getProcessData()));
         //suspend on the other one
         Util.assertFailed(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle2.getProcessData()));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.KILLED);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -146,16 +147,16 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
             //suspend using prismHelper
             Util.assertSucceeded(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle1.getProcessData()));
             //verify
-            checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-            checkStatus(server2, bundle2, Job.Status.RUNNING);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
         }
 
 
         for (int i = 0; i < 2; i++) {
             //suspend on the other one
             Util.assertSucceeded(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle2.getProcessData()));
-            checkStatus(server1, bundle1, Job.Status.SUSPENDED);
-            checkStatus(server2, bundle2, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.SUSPENDED);
+            AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.SUSPENDED);
         }
     }
 
@@ -192,12 +193,12 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
         //suspend using prismHelper
         Util.assertFailed(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle1.getProcessData()));
         //verify
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
 
         //suspend on the other one
         Util.assertSucceeded(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle2.getProcessData()));
-        checkStatus(server2, bundle2, Job.Status.SUSPENDED);
-        checkStatus(server1, bundle1, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.SUSPENDED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.RUNNING);
     }
 
     @Test(groups = {"prism", "0.2"})
@@ -214,14 +215,14 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
         //suspend using prismHelper
         Util.assertFailed(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle1.getProcessData()));
         //verify
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.RUNNING);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.RUNNING);
 
         Util.assertSucceeded(prism.getProcessHelper().delete(Util.URLS.DELETE_URL, bundle2.getProcessData()));
         //suspend on the other one
         Util.assertFailed(prism.getProcessHelper().suspend(Util.URLS.SUSPEND_URL, bundle2.getProcessData()));
-        checkStatus(server1, bundle1, Job.Status.KILLED);
-        checkStatus(server2, bundle2, Job.Status.KILLED);
+        AssertUtil.checkStatus(server1OC, ENTITY_TYPE.PROCESS, bundle1, Job.Status.KILLED);
+        AssertUtil.checkStatus(server2OC, ENTITY_TYPE.PROCESS, bundle2, Job.Status.KILLED);
     }
 
 
@@ -268,10 +269,5 @@ public class PrismProcessSuspendTest extends BaseMultiClusterTests {
         Util.assertSucceeded(coloHelper.getProcessHelper().schedule(Util.URLS.SCHEDULE_URL, bundle.getProcessData()));
     }
 
-
-    private void checkStatus(ColoHelper coloHelper, Bundle bundle, Job.Status expectedStatus) throws Exception {
-        Assert.assertTrue(Util.verifyOozieJobStatus(coloHelper.getFeedHelper().getOozieClient(),
-                Util.readEntityName(bundle.getProcessData()), ENTITY_TYPE.PROCESS, expectedStatus));
-    }
 
 }


### PR DESCRIPTION
Test pass/fail count is same before and after refactoring for all the tests. The only exception is NewPrismProcessUpdateTest for which I was not able to get a run. 
